### PR TITLE
patch 7.4.1377

### DIFF
--- a/src/version.c
+++ b/src/version.c
@@ -748,6 +748,8 @@ static char *(features[]) =
 static int included_patches[] =
 {   /* Add new patch number below this line */
 /**/
+    1377,
+/**/
     1376,
 /**/
     1375,


### PR DESCRIPTION
Problem:    Test_connect_waittime() is flaky.
Solution:   Ignore the "Connection reset by peer" error.