### PR TITLE
patch 8.2.0617: new error check triggers in Swedish menu

### DIFF
--- a/runtime/lang/menu_sv_se.latin1.vim
+++ b/runtime/lang/menu_sv_se.latin1.vim
@@ -1,6 +1,6 @@
 " Menu Translations:    Swedish
 " Maintainer:		Johan Svedberg <johan@svedberg.com>
-" Last Change:		2012 May 01
+" Last Change:		2020 Apr 22
 
 " Quit when menu translations have already been done.
 if exists("did_menu_trans")
@@ -51,7 +51,7 @@ menutrans &Redo<Tab>^R			&Gör\ om<Tab>^R
 menutrans Rep&eat<Tab>\.		&Repetera<Tab>\.
 menutrans Cu&t<Tab>"+x			Klipp\ &ut<Tab>"+x
 menutrans &Copy<Tab>"+y			&Kopiera<Tab>"+y
-menutrans &Paste<Tab>"+gP		Klistra &in<Tab>"+gP
+menutrans &Paste<Tab>"+gP		Klistra\ &in<Tab>"+gP
 menutrans Put\ &Before<Tab>[p		Sätt\ in\ &före<Tab>[p
 menutrans Put\ &After<Tab>]p		Sätt\ in\ &efter<Tab>]p
 menutrans &Select\ All<Tab>ggVG		&Markera\ allt<Tab>ggVG

--- a/src/version.c
+++ b/src/version.c
@@ -747,6 +747,8 @@ static char *(features[]) =
 static int included_patches[] =
 {   /* Add new patch number below this line */
 /**/
+    617,
+/**/
     616,
 /**/
     615,


### PR DESCRIPTION
Problem:    New error check triggers in Swedish menu.
Solution:   Insert backslash. (Mats Tegner, closes #5966)